### PR TITLE
ctl with compressed files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,15 +256,7 @@ jobs:
         timeout-minutes: 1
         run: ls -R
 
-      - name: Generate token to create the release
-        timeout-minutes: 5
-        id: generate_token_cli
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        with:
-          app_id: ${{ secrets.CLI_APP_ID }}
-          private_key: ${{ secrets.CLI_APP_PRIVATE_KEY }}
-
-      - name: Extract binaries from compressed archives
+      - name: Extract binaries from compressed archives (legacy - kept for compatibility)
         timeout-minutes: 5
         run: |
           # Extract all compressed archives to get individual binaries
@@ -295,7 +287,7 @@ jobs:
             omnistrate-ctl-windows-amd64.exe-compressed/omnistrate-ctl-windows-amd64.exe
             omnistrate-ctl-windows-arm64.exe-compressed/omnistrate-ctl-windows-arm64.exe
           repository: omnistrate/cli
-          token: ${{ steps.generate_token_cli.outputs.token }}
+          token: ${{ secrets.PUBLISH_CTL_PAT }}
           fail_on_unmatched_files: true
           draft: false
 
@@ -360,7 +352,7 @@ jobs:
             done
             cd ..
           done
-          
+
       - name: Calculate SHA256 checksums
         id: calculate_sha256
         run: |
@@ -373,20 +365,12 @@ jobs:
           echo "sha_linux_amd64=${sha_linux_amd64}" >> "$GITHUB_OUTPUT"
           echo "sha_linux_arm64=${sha_linux_arm64}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate token to update the formula
-        timeout-minutes: 5
-        id: generate_token_cli
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        with:
-          app_id: ${{ secrets.CLI_APP_ID }}
-          private_key: ${{ secrets.CLI_APP_PRIVATE_KEY }}
-
       - name: Checkout Homebrew Tap repository
         timeout-minutes: 5
         uses: actions/checkout@v4
         with:
           repository: omnistrate/homebrew-tap
-          token: ${{ steps.generate_token_cli.outputs.token }}
+          token: ${{ secrets.PUBLISH_CTL_PAT }}
 
       - name: Display structure of repository
         timeout-minutes: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,25 @@ jobs:
         timeout-minutes: 1
         run: ls -R
 
+      - name: Extract compressed artifacts
+        timeout-minutes: 2
+        run: |
+          # Extract all compressed archives to get individual binaries
+          for dir in omnistrate-ctl-*-compressed/; do
+            cd "$dir"
+            for file in *.tar.gz; do
+              if [ -f "$file" ]; then
+                tar -xzf "$file"
+              fi
+            done
+            for file in *.zip; do
+              if [ -f "$file" ]; then
+                unzip "$file"
+              fi
+            done
+            cd ..
+          done
+
       - name: Run the binary (linux and macos only)
         id: run_binary_linux_macos
         timeout-minutes: 1
@@ -124,7 +143,7 @@ jobs:
           if [ "${{ matrix.os }}" == "macos-latest" ]; then
             export GOOS=darwin
             export GOARCH=arm64
-          elif [ "${{ matrix.os }}" == "ubicloud-standard-2-arm" ]; then
+          elif [ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]; then
             export GOOS=linux
             export GOARCH=arm64
           else
@@ -133,7 +152,7 @@ jobs:
           fi
 
           binary_name="omnistrate-ctl-${GOOS}-${GOARCH}"
-          cd $binary_name
+          cd "${binary_name}-compressed"
           chmod +x $binary_name
           ctl_version=$(./$binary_name --version)
           echo "Omnistrate CTL version: $ctl_version"
@@ -144,7 +163,7 @@ jobs:
         timeout-minutes: 1
         if: matrix.os == 'windows-latest'
         run: |
-          cd omnistrate-ctl-windows-amd64.exe
+          cd omnistrate-ctl-windows-amd64.exe-compressed
           $ctl_version=.\omnistrate-ctl-windows-amd64.exe --version
           echo "Omnistrate CTL version: $ctl_version"
           echo "ctl_version=$ctl_version" >> $env:GITHUB_OUTPUT
@@ -264,7 +283,7 @@ jobs:
             cd ..
           done
 
-      - name: Upload binaries on a new release on cli repo
+      - name: Upload binaries on a new release on cli repo (legacy - kept for compatibility)
         timeout-minutes: 5
         uses: softprops/action-gh-release@v2
         with:
@@ -322,14 +341,32 @@ jobs:
       - name: Display structure of downloaded files
         timeout-minutes: 1
         run: ls -R
-
+        
+      - name: Extract compressed artifacts
+        timeout-minutes: 2
+        run: |
+          # Extract all compressed archives to get individual binaries
+          for dir in omnistrate-ctl-*-compressed/; do
+            cd "$dir"
+            for file in *.tar.gz; do
+              if [ -f "$file" ]; then
+                tar -xzf "$file"
+              fi
+            done
+            for file in *.zip; do
+              if [ -f "$file" ]; then
+                unzip "$file"
+              fi
+            done
+            cd ..
+          done
       - name: Calculate SHA256 checksums
         id: calculate_sha256
         run: |
-          sha_darwin_amd64=$(sha256sum omnistrate-ctl-darwin-amd64/omnistrate-ctl-darwin-amd64 | awk '{ print $1 }')
-          sha_darwin_arm64=$(sha256sum omnistrate-ctl-darwin-arm64/omnistrate-ctl-darwin-arm64 | awk '{ print $1 }')
-          sha_linux_amd64=$(sha256sum omnistrate-ctl-linux-amd64/omnistrate-ctl-linux-amd64 | awk '{ print $1 }')
-          sha_linux_arm64=$(sha256sum omnistrate-ctl-linux-arm64/omnistrate-ctl-linux-arm64 | awk '{ print $1 }')
+          sha_darwin_amd64=$(sha256sum omnistrate-ctl-darwin-amd64-compressed/omnistrate-ctl-darwin-amd64 | awk '{ print $1 }')
+          sha_darwin_arm64=$(sha256sum omnistrate-ctl-darwin-arm64-compressed/omnistrate-ctl-darwin-arm64 | awk '{ print $1 }')
+          sha_linux_amd64=$(sha256sum omnistrate-ctl-linux-amd64-compressed/omnistrate-ctl-linux-amd64 | awk '{ print $1 }')
+          sha_linux_arm64=$(sha256sum omnistrate-ctl-linux-arm64-compressed/omnistrate-ctl-linux-arm64 | awk '{ print $1 }')
           echo "sha_darwin_amd64=${sha_darwin_amd64}" >> "$GITHUB_OUTPUT"
           echo "sha_darwin_arm64=${sha_darwin_arm64}" >> "$GITHUB_OUTPUT"
           echo "sha_linux_amd64=${sha_linux_amd64}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,7 +341,7 @@ jobs:
       - name: Display structure of downloaded files
         timeout-minutes: 1
         run: ls -R
-        
+
       - name: Extract compressed artifacts
         timeout-minutes: 2
         run: |
@@ -360,6 +360,7 @@ jobs:
             done
             cd ..
           done
+          
       - name: Calculate SHA256 checksums
         id: calculate_sha256
         run: |


### PR DESCRIPTION
use compressed files for releases
use path instead of an app to be able to move to the oss org